### PR TITLE
fix obvious bugs in training script.

### DIFF
--- a/train_nerf.py
+++ b/train_nerf.py
@@ -168,7 +168,7 @@ def main():
 
         model_coarse.train()
         if model_fine:
-            model_coarse.train()
+            model_fine.train()
 
         rgb_coarse, rgb_fine = None, None
         target_ray_values = None
@@ -292,7 +292,7 @@ def main():
             tqdm.write("[VAL] =======> Iter: " + str(i))
             model_coarse.eval()
             if model_fine:
-                model_coarse.eval()
+                model_fine.eval()
 
             start = time.time()
             with torch.no_grad():


### PR DESCRIPTION
the training script fail to switch model's train/eval mode(`model_fine.train()` and `model_fine.eval()`).
Since no BN is used in the NeRF, maybe this bug make no difference for now.
but may mislead the research based on this implementation. 